### PR TITLE
Fix 'new_job' error

### DIFF
--- a/topchef_client/models/job.py
+++ b/topchef_client/models/job.py
@@ -43,7 +43,7 @@ class Job(object):
         :return: The result for the job
         :rtype: object
         """
-        return self.job_details['result']
+        return self.job_details['results']
 
     @result.setter
     def result(self, new_result):

--- a/topchef_client/models/service.py
+++ b/topchef_client/models/service.py
@@ -88,7 +88,7 @@ class Service(object):
         if new_job_response.status_code != self.HTTP_STATUS_CODE_CREATED:
             self._handle_job_not_created_error(new_job_response.status_code)
 
-        new_job_id = new_job_response.json()['data']['job_details']['id']
+        new_job_id = new_job_response.json()['data']['id']
 
         return Job(self.topchef_url, new_job_id, self._http_library)
 


### PR DESCRIPTION
This fixes the key error I was getting when creating a new job. 

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-6-51556df32305> in <module>()
----> 1 job = service.new_job(experiment_parameters)

/home/ihincks/.local/share/miniconda2/envs/nvadapt/lib/python2.7/site-packages/topchef_client/models/service.pyc in new_job(self, parameters, validator_factory)
     89             self._handle_job_not_created_error(new_job_response.status_code)
     90 
---> 91         new_job_id = new_job_response.json()['data']['job_details']['id']
     92 
     93         return Job(self.topchef_url, new_job_id, self._http_library)

KeyError: 'job_details'

```
